### PR TITLE
Django 2 support

### DIFF
--- a/django_cloneable/models.py
+++ b/django_cloneable/models.py
@@ -172,6 +172,7 @@ class ModelCloneHelper(object):
             duplicate.clone_m2m = clone_m2m
         return duplicate
 
+
 def _get_remote_field(field):
     if hasattr(field, 'remote_field'):
         # Django 2
@@ -180,6 +181,7 @@ def _get_remote_field(field):
         # Django <= 1.11
         return field.rel
     return None
+
 
 class CloneableMixin(models.Model):
     ''' Adds a clone() method to models

--- a/django_cloneable/models.py
+++ b/django_cloneable/models.py
@@ -82,7 +82,12 @@ class ModelCloneHelper(object):
             # normal m2m, this is easy
             else:
                 objs = getattr(self.instance, field.attname).all()
-                setattr(duplicate, field.attname, objs)
+                try:
+                    # Django <= 1.11
+                    setattr(duplicate, field.attname, objs)
+                except TypeError:
+                    # Django 2
+                    getattr(duplicate, field.name).set(objs)
 
     def _clone_copy_reverse_m2m(self, duplicate, exclude=None):
         exclude = exclude or []
@@ -128,7 +133,12 @@ class ModelCloneHelper(object):
                     self.instance,
                     remote_field.related_name)
                 objs = objs_rel_manager.all()
-                setattr(duplicate, relation.field.rel.related_name, objs)
+                try:
+                    # Django <= 1.11
+                    setattr(duplicate, remote_field.related_name, objs)
+                except TypeError:
+                    # Django 2
+                    getattr(duplicate, remote_field.related_name).set(objs)
 
     def clone(self, attrs=None, commit=True, m2m_clone_reverse=True,
               exclude=None):


### PR DESCRIPTION
There were model relationship changes that were deprecated in Django 1.11 => 2.0.

These two commits attempt to make the code work for both Django <= 1.11 and >= 2.0.

The first changes `field.rel` to `field.remote_field` as `field.rel` was deprecated in 1.11 and removed in 2.0.

The second changes the way many-to-many assignments are made. Django 2 doesn't support direct assignment to the fields; instead it requires using the `set()` method on the field.

Unfortunately, I'm not familiar with tox and I wasn't able to get the tests to run. I always get an `InvocationError for command` error. Do you have any advice on getting them to run? I set up a virtualenv, installed the deps in `/requirements.txt`, and then just ran `tox`.

Thanks for checking this out and please let me know if there's anything I can change with the code or do to update the tests to run successfully!