### PR TITLE
Prevents ModelState instance from being shared by model and clone

### DIFF
--- a/django_cloneable/models.py
+++ b/django_cloneable/models.py
@@ -14,7 +14,9 @@ class ModelCloneHelper(object):
         import copy
         if not self.instance.pk:
             raise ValueError('Instance must be saved before it can be cloned.')
-        return copy.copy(self.instance)
+        duplicate = copy.copy(self.instance)
+        duplicate._state = models.base.ModelState()
+        return duplicate
 
     def _clone_prepare(self, duplicate, exclude=None):
         # Setting pk to None tricks Django into not trying to overwrite the old

--- a/tests/models.py
+++ b/tests/models.py
@@ -9,7 +9,12 @@ class ModelWithFields(CloneableMixin, models.Model):
     integer = models.IntegerField(default=0)
     date = models.DateField(default=date(2000, 1, 1))
 
-
 class ModelWithCustomPK(CloneableMixin, models.Model):
     key = models.CharField(max_length=50, primary_key=True)
     value = models.IntegerField()
+
+class RelatedModel(models.Model):
+	pass
+
+class ModelWithFK(CloneableMixin, models.Model):
+	related = models.ForeignKey(RelatedModel, related_name='+', null=True, on_delete=models.SET_NULL)

--- a/tests/test_cloneable.py
+++ b/tests/test_cloneable.py
@@ -3,6 +3,8 @@ from django.test import TestCase
 
 from .models import ModelWithCustomPK
 from .models import ModelWithFields
+from .models import RelatedModel
+from .models import ModelWithFK
 
 
 class CloneableTests(TestCase):
@@ -27,3 +29,13 @@ class CloneableTests(TestCase):
         assert i2.pk == 'bar'
         assert i1.pk != i2.pk
         assert i2.value == 42
+
+    def test_cloning_object_allows_overwriting_fk_reference(self):
+        i1 = ModelWithFK.objects.create()
+        i1.related = RelatedModel.objects.create()
+        i1.save()
+
+        i2 = i1.clone()
+        i2.related = RelatedModel.objects.create()
+        i2.save()
+        assert i1.related != i2.related


### PR DESCRIPTION
I was running into an issue where assigning a new foreign key reference to an object after cloning it was causing the reference to change on both the original and cloned object.

For example:
```
model = MyModel.objects.create()
model.author = Author.objects.create(name="Kurt Vonnegut")
model.save()
duplicate = model.clone()
duplicate.author = Author.objects.create(name="Douglas Adams")
duplicate.save()

model.author == duplicate.author
# => True, both are "Douglas Adams"
```

This was happening because of the `ModelState` object instance attached to the `model._state` key.  When the model is copied with `copy.copy(self.instance)` the keys and values in `__dict__` are copied over to the new instance. `_state` is included in the `__dict__` so then both model instances end up pointing at the same instance of the model state, thus causing assignments to one foreign key field to change the value of the other foreign key field.

The `ModelState` object keeps a `fields_cache` dictionary that seems to be the culprit to this duplicate assignment.

Additionally, `ModelState` has an `adding` key that [triggers validation uniqueness checks for new objects](https://github.com/django/django/blob/master/django/db/models/base.py#L391-L395) which could cause additional problems for some models if not reset to `True`

Since `_state` is a non-public attribute, setting `_state.adding = True` and `_state.fields_cache = {}` could potentially break in future versions of Django. Instead, it seemed less brittle to re-initialize `_state` to `ModelState()` so it will behave as if it was freshly loaded from the database.

I also added tests for this case.